### PR TITLE
Adding basic AI infra files for new repos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ application itself: it generates Python projects.
 - `tests/test_template.py` — the template test suite (generates projects with
   `cruft` and asserts on the output).
 
+Note: `AGENTS.md` / `CLAUDE.md` exist at two levels. This root pair documents
+the template repo itself; the pair under `{{cookiecutter.project_name}}/` ships
+into generated projects and must describe the *generated* project (and stay
+valid Jinja).
+
 ## Tooling
 
 - Top-level source (`hooks/`, `tests/`) is linted and tested.
@@ -28,3 +33,7 @@ application itself: it generates Python projects.
 - When editing files under `{{cookiecutter.project_name}}/`, keep the Jinja
   valid and make sure `nox -s tests` still passes — the suite renders the
   template with `cruft` and checks the generated project.
+- When adding, removing, or renaming files under `{{cookiecutter.project_name}}/`,
+  update the assertions in `tests/test_template.py` (essential files, rendering
+  checks). Files gated by the `docs` variable also need
+  `hooks/post_gen_project.py` updated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Guide
+
+This repository is a [cookiecutter](https://cookiecutter.readthedocs.io/) /
+[cruft](https://cruft.github.io/cruft/) **Python project template**. It is not an
+application itself: it generates Python projects.
+
+## Layout
+
+- `{{cookiecutter.project_name}}/` — the template of the generated project. Files
+  here are rendered with Jinja and may contain `{{ ... }}` / `{% ... %}` syntax.
+- `cookiecutter.json` — the template variables and their defaults.
+- `hooks/` — pre/post generation hooks that run during `cruft create`.
+- `tests/test_template.py` — the template test suite (generates projects with
+  `cruft` and asserts on the output).
+
+## Tooling
+
+- Top-level source (`hooks/`, `tests/`) is linted and tested.
+- The `{{cookiecutter.project_name}}/` tree is **excluded from ruff** (see
+  `extend-exclude` in `pyproject.toml`) because it contains Jinja, not valid
+  Python/TOML/YAML until rendered.
+
+## Workflow rules
+
+- After making changes, **always run `nox -s lint`** and fix every issue it
+  reports. Repeat the loop (edit, re-run `nox -s lint`) until it passes cleanly.
+- Run `nox -s tests` (pytest) to verify template generation still works.
+- When editing files under `{{cookiecutter.project_name}}/`, keep the Jinja
+  valid and make sure `nox -s tests` still passes — the suite renders the
+  template with `cruft` and checks the generated project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -108,6 +108,8 @@ class TestProjectStructure:
         essential = [
             "README.md",
             "CONTRIBUTING.md",
+            "AGENTS.md",
+            "CLAUDE.md",
             "LICENSE",
             "pyproject.toml",
             "noxfile.py",
@@ -186,6 +188,7 @@ class TestMarkdownDocumentation:
         files_to_check = [
             "README.md",
             "CONTRIBUTING.md",
+            "AGENTS.md",
             "pyproject.toml",
         ]
 

--- a/{{cookiecutter.project_name}}/AGENTS.md
+++ b/{{cookiecutter.project_name}}/AGENTS.md
@@ -29,7 +29,9 @@ $ source .venv/bin/activate
 
 Run tasks via nox (`nox --list-sessions` shows everything available):
 
-- `nox -s tests` — run the test suite with coverage (pytest).
+- `nox -s tests` — run the test suite with coverage (pytest) across all
+  supported Python versions; use e.g. `nox -s tests-3.12 -- -k <expr>` for a
+  single version/subset.
 - `nox -s lint` — run all pre-commit checks (ruff lint, formatting, codespell, …).
 - `nox -s fmt` — apply ruff formatting.
 - `nox -s build` — build the distribution and check it with twine.
@@ -43,7 +45,7 @@ Run tasks via nox (`nox --list-sessions` shows everything available):
 - Ruff is configured with `select = ["ALL"]` in `pyproject.toml`; keep the code
   compliant rather than adding blanket ignores.
 - Tests live in `tests/` and use pytest; maintain coverage for new code.
-- Type hints are expected (ruff flake8-type-checking is enabled).
+- Type hints are expected (ruff `ANN` rules are enabled via `select = ["ALL"]`).
 
 ## Workflow rules
 

--- a/{{cookiecutter.project_name}}/AGENTS.md
+++ b/{{cookiecutter.project_name}}/AGENTS.md
@@ -1,0 +1,52 @@
+# Agent Guide
+
+Guidance for working on **{{ cookiecutter.friendly_name }}**, a Python project.
+
+## Project layout
+
+- `src/{{ cookiecutter.package_name }}/` — the package source code.
+- `tests/` — the test suite (pytest).
+- `pyproject.toml` — project metadata and tool configuration (ruff, pytest,
+  coverage).
+- `.pre-commit-config.yaml` — pre-commit hooks (ruff, ruff-format, codespell,
+  file/formatting checks).
+- `noxfile.py` — task automation entry points.
+- `.github/workflows/` — CI (tests, release, semgrep, secret scanning{% if cookiecutter.docs %}, docs{% endif %}).
+
+## Environment
+
+This project uses [uv](https://docs.astral.sh/uv/) for environments and installs,
+and [nox](https://nox.thea.codes/) as the task runner.
+
+Set up a development environment:
+
+```console
+$ nox -s dev
+$ source .venv/bin/activate
+```
+
+## Tasks
+
+Run tasks via nox (`nox --list-sessions` shows everything available):
+
+- `nox -s tests` — run the test suite with coverage (pytest).
+- `nox -s lint` — run all pre-commit checks (ruff lint, formatting, codespell, …).
+- `nox -s fmt` — apply ruff formatting.
+- `nox -s build` — build the distribution and check it with twine.
+{%- if cookiecutter.docs %}
+- `nox -s docs` — build the documentation with mkdocs.
+{%- endif %}
+- `nox -s semgrep-fast` / `nox -s semgrep-all` — run security scans.
+
+## Conventions
+
+- Ruff is configured with `select = ["ALL"]` in `pyproject.toml`; keep the code
+  compliant rather than adding blanket ignores.
+- Tests live in `tests/` and use pytest; maintain coverage for new code.
+- Type hints are expected (ruff flake8-type-checking is enabled).
+
+## Workflow rules
+
+- After making changes, **always run `nox -s lint`** and fix every issue it
+  reports. Repeat the loop (edit, re-run `nox -s lint`) until it passes cleanly.
+- Run `nox -s tests` before finishing to make sure the suite still passes.

--- a/{{cookiecutter.project_name}}/CLAUDE.md
+++ b/{{cookiecutter.project_name}}/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

Adds agent instruction files (`AGENTS.md` + `CLAUDE.md`) at both levels of the template:

- **Root `AGENTS.md`** — guide for agents working on the template repo itself: layout (template tree, `cookiecutter.json`, hooks, tests), why `{{cookiecutter.project_name}}/` is excluded from ruff (unrendered Jinja), and workflow rules (`nox -s lint` / `nox -s tests` loop, keeping test assertions in sync when template files are added/removed).
- **`{{cookiecutter.project_name}}/AGENTS.md`** — Jinja-templated guide that ships into every generated project: layout, uv/nox environment setup, available nox sessions (docs session included conditionally via the `docs` flag), and conventions (ruff `select = ["ALL"]`, type hints, coverage).
- **`CLAUDE.md`** at both levels is a one-line `@AGENTS.md` import, so Claude Code and AGENTS.md-standard tools share a single source of truth.

## Tests

`tests/test_template.py` now asserts that generated projects contain `AGENTS.md` and `CLAUDE.md`, and includes `AGENTS.md` in the unrendered-Jinja-syntax check (it is the most Jinja-heavy markdown file in the template).

`nox -s lint` and `nox -s tests` (11 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)